### PR TITLE
Use average render time in previewer playback loop. Fixes #91.

### DIFF
--- a/src/js/modules/previewer.js
+++ b/src/js/modules/previewer.js
@@ -201,8 +201,8 @@ function createReplay(id, positions) {
       [frame, duration] = value;
       renderer.draw(frame);
       slider.value = frame;
-
-      playInterval = setTimeout(animate, duration);
+      let average_render_time = (renderer.total_render_time / renderer.rendered_frames);
+      playInterval = setTimeout(animate, duration - average_render_time);
     });
   }
 

--- a/src/js/modules/renderer.js
+++ b/src/js/modules/renderer.js
@@ -33,6 +33,9 @@ class Renderer {
     this.canvas = canvas;
     this.replay = replay;
     this.options = these_options;
+
+    this.total_render_time = 0;
+    this.rendered_frames = 0;
     
     this.ready_promise = Textures.get(options.custom_textures).then((result) => {
       textures = result;
@@ -47,8 +50,12 @@ class Renderer {
   }
 
   draw(frame) {
+    let t0 = performance.now();
     animateReplay(frame, this.replay, this.map, this.options.spin,
       this.options.splats, this.options.ui, this.options.chats);
+    let t1 = performance.now();
+    this.total_render_time += t1 - t0;
+    this.rendered_frames++;
   }
 
   _extract_replay_data() {


### PR DESCRIPTION
We were just using the expected frame duration in the setTimeout for the
next loop iteration. This takes into account the time to render the next
frame and loops quick enough so it looks smooth.

Testing done:

* Calculated average difference between frame duration and loop speed in
  previewer.js > play. Before the change it was around 5-7ms and
  afterwards it was around 1-2ms (which is within the margin of error I
  was seeing for setTimeout).