### PR TITLE
Refactor replay chat handling. Fixes #104.

### DIFF
--- a/src/js/modules/previewer.js
+++ b/src/js/modules/previewer.js
@@ -2,7 +2,7 @@ const $ = require('jquery');
 const loadImage = require('image-promise');
 
 const Cookies = require('./cookies');
-const Renderer = require('./renderer');
+const get_renderer = require('./renderer');
 const logger = require('./logger')('renderer');
 
 function get_options() {
@@ -84,9 +84,9 @@ function createReplay(id, positions) {
 
   var renderer;
   get_options().then((opts) => {
-    renderer = new Renderer(can, positions, opts);
-    return renderer.ready();
-  }).then(() => {
+    return get_renderer(can, positions, opts);
+  }).then((created_renderer) => {
+    renderer = created_renderer;
     logger.info('Renderer loaded.');
     renderer.draw(frame);
   });

--- a/src/js/recording.js
+++ b/src/js/recording.js
@@ -86,9 +86,18 @@ function recordReplayData() {
   }
 
   // set up listener for chats, splats, and bombs
-  tagpro.socket.on('chat', function (CHAT) {
-    CHAT.removeAt = Date.now() + chat_duration;
-    positions.chat.push(CHAT);
+  tagpro.socket.on('chat', function (chat) {
+    let attributes = {};
+    if (typeof chat.from == 'number') {
+      // Preserve player attributes at time chat was made.
+      let player = tagpro.players[chat.from];
+      attributes.name = player.name;
+      attributes.auth = player.auth;
+      attributes.team = player.team;
+    }
+    let chat_info = Object.assign(attributes, chat);
+    chat_info.removeAt = Date.now() + chat_duration;
+    positions.chat.push(chat);
   });
 
   tagpro.socket.on('splat', function (SPLAT) {

--- a/src/js/recording.js
+++ b/src/js/recording.js
@@ -97,7 +97,7 @@ function recordReplayData() {
     }
     let chat_info = Object.assign(attributes, chat);
     chat_info.removeAt = Date.now() + chat_duration;
-    positions.chat.push(chat);
+    positions.chat.push(chat_info);
   });
 
   tagpro.socket.on('splat', function (SPLAT) {


### PR DESCRIPTION
Chat messages represent information as it was when the chat occurred,
but we were treating the player/auth/team attribute of them as if they
corresponded to the frame being rendered. To fix this there were 3
changes:

1. When recording a replay, save the name, auth, and team attribute of
   the originating player.
2. Before rendering the replay, pre-process the replay to make the
   format of the chat objects consistent with what we expect. This is
   simpler than handling all cases in the chat rendering itself.
3. When cropping replays, ensure that chat objects are using the new
   format.

Barring a capability to do replay upgrade (as mentioned in #58), this is
the best we can do and should cover all cases.

Also I hid the Renderer behind a function to force consumers of it to
wait on the Promise, which should be easier than remembering to wait on
Renderer#ready.

Testing done:

* Render and preview the replay mentioned in #104.
* Record a new replay and preview/render it, ensuring all expected chats
  were present.
* Preview a few other test replays with known chats.