### PR TITLE
Change default replay name. Fixes #22.

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -584,6 +584,22 @@ function make_replay_list(ids, rendered_ids, metadata) {
   return replays;
 }
 
+// Generate a new replay name.
+// Current default is: {count:0>4}_replay_{timestamp}
+function get_new_replay_name() {
+  let prefix_length = 4;
+  // We'll just keep it in localStorage, not super critical.
+  if (!localStorage.getItem('counter')) {
+    localStorage.setItem('counter', '1');
+  }
+  let max_val = Math.pow(10, prefix_length);
+  let current = Math.max(Number(localStorage.getItem('counter')) % max_val, 1);
+  let prefix = ('0'.repeat(prefix_length) + current).slice(-prefix_length);
+  localStorage.setItem('counter', ++current);
+  let timestamp = Date.now();
+  return `${prefix}_replay_${timestamp}`;
+}
+
 var title;
 // Guard against multi-page rendering.
 let rendering = false;
@@ -728,6 +744,11 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
   } else if (method == 'replay.save_record') {
     let {name, data} = message;
+    if (!name) {
+      name = get_new_replay_name();
+    }
+    // We store date recorded in the name of the replay.
+    name = `${name}DATE${Date.now()}`;
     try {
       let parsed = JSON.parse(data);
       parsed = trimReplay(parsed);

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -985,16 +985,20 @@ function listen(event, listener) {
 
 // set up listener for info from injected script
 // if we receive data, send it along to the background script for storage
+// Listens for recorded replay from recording script.
+// info is an object with:
+// @property {string} data  JSON formatted data
+// @property {string?} name  optional name
 listen('replay.save', function (info) {
-    logger.info('got position data from injected script. sending to background script')
+    logger.info('Received recording, sending to background page.');
     chrome.runtime.sendMessage({
         method: 'replay.save_record',
         data: info.data,
         name: info.name
     }, (result) => {
         emit('replay.saved', {
-            failed: result
-        })
+            failed: result.failed
+        });
     });
 });
 

--- a/src/js/recording.js
+++ b/src/js/recording.js
@@ -546,8 +546,7 @@ function saveReplayData(positions) {
   var data = JSON.stringify(positions);
   logger.info('Sending replay to content script.');
   emit('replay.save', {
-    data: data,
-    name: `replays${Date.now()}`
+    data: data
   });
 }
 
@@ -566,7 +565,7 @@ listen('replay.saved', function (result) {
   } else {
     $('savedFeedback').removeClass('failed');
     $('savedFeedback').text('Saved!');
-  }}
+  }
   $(savedFeedback).fadeIn(300);
   $(savedFeedback).fadeOut(900);
 });


### PR DESCRIPTION
Testing done:
1. Change prefix length and ensure count wraps properly when recording
2. Remove count from local storage, make sure first replay recorded
   has valid name.