### PR TITLE
Update schema to allow null auth in chat. Fixes #149.

### DIFF
--- a/src/schemas/1/main.json
+++ b/src/schemas/1/main.json
@@ -67,7 +67,7 @@
           "description": "New chat format introduced to fix #104",
           "properties": {
             "auth": {
-              "type": "boolean"
+              "type": ["boolean", "null"]
             },
             "c": {
               "description": "Optional text color.",


### PR DESCRIPTION
Not sure why auth may be null instead of false but it doesn't impact
anything else.

Testing done:
1. Import replay from #149 successfully.