### PR TITLE
Fix previewer control position for Chrome < 52.

### DIFF
--- a/src/scss/viewer.scss
+++ b/src/scss/viewer.scss
@@ -58,7 +58,7 @@
     }
 
     #viewer-controls {
-        position: absolute;
+        position: relative;
         bottom: 0;
     }
 }
@@ -209,9 +209,6 @@
 #tpr-viewer-container #viewer-controls {
     height: 58px;
     width: 100%;
-    // force to bottom of viewer.
-    bottom: 0;
-    position: absolute;
 }
 
 .progress-main {


### PR DESCRIPTION
Absolutely positioned child elements are treated like 0x0 flex
elements until Chrome 52. Fixes #159.

Testing done:

* Viewed a replay using previewer on Chromium 50.