### PR TITLE
Fix render response from background page.

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1052,11 +1052,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     logger.info(`Received request to download movie for: ${id}.`);
     Movies.get(id).then((file) => {
       return get_replay_info(id).then((info) => {
+        logger.debug(`Downloading movie for ${id}.`);
         let filename = sanitize(info.name);
-        saveAs(file, filename);
-      });
-      sendResponse({
-        failed: false
+        saveAs(file, `${filename}.webm`);
+        sendResponse({
+          failed: false
+        });
       });
     }).catch((err) => {
       logger.error('Error downloading movie: ', err);


### PR DESCRIPTION
The background page was misbehaving in 2 ways:
1. Rendered movie was not given a file extension
2. `sendResponse` was not called and on GC an error was displaying
   on the content script (since now we check `chrome.runtime.lastError`.

Now we provide a file extension and the call to `sendResponse` in the
success case has been moved to the correct location (after the rendered
replay save). Fixes #166 and #167.

Testing done:
1. Render a replay.
2. Download a rendered replay.
3. Check the console to ensure that the message logged on download
   completion is actually traced.