### PR TITLE
Add rendering of marsball.

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -673,18 +673,18 @@ function cropReplayData(replay, start, end) {
   }
 
   let new_replay = {
-    bombs:      cropBombs(replay.bombs),
-    chat:       cropChats(replay.chat),
-    clock:      cropFrameArray(replay.clock),
-    end:        replay.end,
+    bombs: cropBombs(replay.bombs),
+    chat: cropChats(replay.chat),
+    clock: cropFrameArray(replay.clock),
+    end: replay.end,
     gameEndsAt: replay.gameEndsAt,
     floorTiles: replay.floorTiles.map(cropDynamicTile),
-    map:        replay.map,
-    objects:    {},
-    score:      cropFrameArray(replay.score),
-    spawns:     cropSpawns(replay.spawns),
-    splats:     cropSplats(replay.splats),
-    wallMap:    replay.wallMap
+    map: replay.map,
+    objects: {},
+    score: cropFrameArray(replay.score),
+    spawns: cropSpawns(replay.spawns),
+    splats: cropSplats(replay.splats),
+    wallMap: replay.wallMap
   };
   // Add players.
   for (let key in replay) {
@@ -704,6 +704,9 @@ function cropReplayData(replay, start, end) {
   }
   if ('event' in replay) {
     new_replay.event = cropEvent(replay.event);
+  }
+  if ('tagproVersion' in replay) {
+    new_replay.tagproVersion = replay.tagproVersion;
   }
   return new_replay;
 }

--- a/src/js/modules/renderer.js
+++ b/src/js/modules/renderer.js
@@ -1005,6 +1005,16 @@ function drawObjects(positions) {
         // Offset
         pos.x - 8, pos.y - 8,
         ball_size, ball_size);
+    } else if (obj.type == 'marsball') {
+      if (!obj.draw[frame]) continue;
+      let descriptor = Tiles.tiles.marsball;
+      let pos = worldToScreen(obj.x[frame] - TILE_SIZE / 2,
+                              obj.y[frame] - TILE_SIZE / 2);
+      context.drawImage(textures.tiles,
+        descriptor.x * TILE_SIZE, descriptor.y * TILE_SIZE,
+        descriptor.size, descriptor.size,
+        pos.x, pos.y,
+        descriptor.size, descriptor.size);
     } else {
       continue;
     }

--- a/src/js/recording.js
+++ b/src/js/recording.js
@@ -49,6 +49,7 @@ function recordReplayData() {
   positions.score = createZeroArray(frames);
   positions.gameEndsAt = [new Date(tagpro.gameEndsAt).getTime()];
   positions.clock = createZeroArray(frames);
+  positions.tagproVersion = tagpro.version;
 
   // Set up dynamic tiles.
   const dynamic_tile_ids = [3, 4, 5, 6, 9, 10, 13, 14, 15, 16, 19, 20, 21];

--- a/src/schemas/1/main.json
+++ b/src/schemas/1/main.json
@@ -443,6 +443,11 @@
           "maxItems": 4
         }
       }
+    },
+    "tagproVersion": {
+      "title": "TagPro Version",
+      "description": "Version of the TagPro client code for the recording, for forward compatibility in case of changes. Default should be assumed 3.2.1 (the value when this was implemented)",
+      "type": "string"
     }
   },
   "patternProperties": {


### PR DESCRIPTION
As part of the Easter update we were already tracking entities contained
in `tagpro.objects`, this just adds rendering of objects with type
`marsball`.

The offset is the default for players and objects, including the
marsball. The value is kind of strange so in anticipation of it getting
updated to something else, a `tagproVersion` attribute has also been
added to recorded replays.

Fixes #79.