### PR TITLE
Use URL to parse document.URL

### DIFF
--- a/src/js/content.js
+++ b/src/js/content.js
@@ -24,6 +24,7 @@ const Table = require('modules/table');
 const Upload = require('modules/upload');
 const Search = require('modules/search');
 
+const url = new URL(document.URL);
 // Get URL for setting cookies, assumes a domain of *.hostname.tld:*/etc
 var cookieDomain = document.URL.match(/https?:\/\/[^\/]+?(\.[^\/.]+?\.[^\/.]+?)(?::\d+)?\//)[1];
 
@@ -792,7 +793,7 @@ if ($('#userscript-home').length !== 0) {
   // Include custom bootstrap.css scoped to #tpr-container
   injectStyleSheet("css/bootstrap.css");
   injectStyleSheet("css/menu.css");
-} else if (document.URL.search(/\.\w+:/) >= 0
-        || document.URL.endsWith('/game')) {
+} else if (url.port !== ''
+        || url.pathname === '/game') {
   injectScript('js/recording.js');
 }

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -24,7 +24,6 @@ const Table = require('modules/table');
 const Upload = require('modules/upload');
 const Search = require('modules/search');
 
-const url = new URL(document.URL);
 // Get URL for setting cookies, assumes a domain of *.hostname.tld:*/etc
 var cookieDomain = document.URL.match(/https?:\/\/[^\/]+?(\.[^\/.]+?\.[^\/.]+?)(?::\d+)?\//)[1];
 
@@ -783,6 +782,7 @@ function injectStyleSheet(path) {
   (document.head || document.documentElement).appendChild(link);
 }
 
+const url = new URL(document.URL);
 // if we're on the main tagpro server screen, run the createReplayPageButton function
 if ($('#userscript-home').length !== 0) {
   // make the body scrollable
@@ -793,7 +793,6 @@ if ($('#userscript-home').length !== 0) {
   // Include custom bootstrap.css scoped to #tpr-container
   injectStyleSheet("css/bootstrap.css");
   injectStyleSheet("css/menu.css");
-} else if (url.port !== ''
-        || url.pathname === '/game') {
+} else if (url.port !== '' || url.pathname === '/game') {
   injectScript('js/recording.js');
 }


### PR DESCRIPTION
Sometimes we add querystring params to the game url like `?spectator=true`.

This uses https://developer.mozilla.org/en-US/docs/Web/API/URL to determine if the pathname is `/game` or if there is a port. Check that the browser support for it is what you'd like.

If you aren't keen on using `URL` to parse. Here's a regex that supports querystrings and hashes.

`/(?:\.com|\.gg)\/game(?:[?#].*)?$/`

<img width="635" alt="screen shot 2018-12-21 at 1 39 56 pm" src="https://user-images.githubusercontent.com/5234033/50358045-027aa900-0526-11e9-8c53-ef1dfc5322b8.png">
