### PR TITLE
Use any protocol for koalabeast.com urls

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -25,7 +25,7 @@
       "css/viewer.css"
     ],
     "matches": [
-      "http://*.koalabeast.com/*",
+      "*://*.koalabeast.com/*",
       "http://*.newcompte.fr/*",
       "http://tangent.jukejuice.com/*"
     ],


### PR DESCRIPTION
TagPro is using https now so http match patterns no longer work.