### PR TITLE
Render replays more reliably

### DIFF
--- a/src/js/modules/renderer.js
+++ b/src/js/modules/renderer.js
@@ -295,7 +295,13 @@ class Renderer {
 function decipherMapdata(mapData) {
   return mapData.map((col) => {
     return col.map((tile) => {
-      return Object.assign({}, Tiles.mapElements[tile]);
+      let tileDescriptor = Tiles.mapElements[tile];
+      if (tileDescriptor === undefined) {
+        // Default to a blank tile.
+        tileDescriptor = Tiles.mapElements[0];
+        logger.error(`Could not find tile for value: ${tile}`);
+      }
+      return Object.assign({}, tileDescriptor);
     });
   });
 }

--- a/src/js/modules/renderer.js
+++ b/src/js/modules/renderer.js
@@ -770,7 +770,7 @@ function drawFloorTiles(positions, showPreviews) {
     const tile_spec = Tiles.floor_tiles[tile_value];
     if (!tile_spec) {
       render_state.report_missing_tile(tile_value, "Tiles.floor_values");
-      return;
+      continue;
     }
     if (!tile_spec.preview) {
       x = tile_spec.animated ? animationTile

--- a/src/js/modules/renderer.js
+++ b/src/js/modules/renderer.js
@@ -110,6 +110,17 @@ class Renderer {
       world_offset: {
         x: 0,
         y: 0
+      },
+      _missing_tiles: new Set(),
+      /**
+       * @param {string|number} value
+       */
+      report_missing_tile(value) {
+        if (this._missing_tiles.has(value)) {
+          return;
+        }
+        logger.error(`Error locating floor tile for ${value}`);
+        this._missing_tiles.add(value);
       }
     };
     this.options = these_options;
@@ -755,9 +766,10 @@ function drawFloorTiles(positions, showPreviews) {
   }
   for (let floor_tile of positions.floorTiles) {
     let x, y;
-    let tile_spec = Tiles.floor_tiles[floor_tile.value[frame]];
+    const tile_value = floor_tile.value[frame];
+    const tile_spec = Tiles.floor_tiles[tile_value];
     if (!tile_spec) {
-      logger.error(`Error locating floor tile description for ${floor_tile.value[frame]}`);
+      render_state.report_missing_tile(tile_value, "Tiles.floor_values");
       return;
     }
     if (!tile_spec.preview) {


### PR DESCRIPTION
When new tiles are added to the game, users could not render or preview replays.

This fixes the issue in two ways:

1. When an unrecognized tile is present in the TagPro map of a replay, we substitute a blank tile (which renders as a black square)
2. When an unrecognized dynamic tile is present in the dynamic floor tiles of a replay, we log once and skip that tile - previously we would log every time and skip the rest of the dynamic tiles for that frame, but that leads to a poor user experience since many tiles may be skipped

Fixes #257.