### PR TITLE
Remove auth as required property in chat

### DIFF
--- a/src/schemas/1/main.json
+++ b/src/schemas/1/main.json
@@ -120,7 +120,6 @@
             }
           },
           "required": [
-            "auth",
             "from",
             "message",
             "name",


### PR DESCRIPTION
Removing `auth` as a required property as chat messages may not have it in the body. I assume that null cases have already been handled elsewhere in the code because the schema already accepts `"auth": null`. Hopefully lol.

```
{
  "name":"Some Ball 1",
  "team":2,
  "from":1,
  "message":"im bad",
  "to":"team",
  "removeAt":1666981608117
}
```

Should address #296.